### PR TITLE
Fix outputting multiple files

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -7,7 +7,7 @@ var program = require('commander');
 var Mustang = require('./mustang');
 
 /**
- * 
+ *
  */
 function init() {
   program.option('-t, --template <template_file>', 'Mustache template file path')
@@ -21,7 +21,7 @@ function init() {
          .option('--user <user>', 'Username for input URL or datasource')
          .option('--password <password>', 'Password for input URL or datasource')
          .option('-c, --collection <collection>', 'Querying collection(table) in datasource')
-         .option('-q, --query <query>', 
+         .option('-q, --query <query>',
            'Query string for datasource. In RDBMS type data source you can set SQL. ' +
            'In MongoDB, URL style query is accepted (<collection>?<prop1>=<value1>&<prop2>=<value2>)')
          .option('--filter <filter>', 'Filter string to filter returning records from datasource')

--- a/lib/file.js
+++ b/lib/file.js
@@ -15,7 +15,7 @@ module.exports.read = function(filepath, options, callback) {
   try {
     var fstat = fs.statSync(filepath);
   } catch(e) {
-    return callback(new Error('No such file: ' + filepath)); 
+    return callback(new Error('No such file: ' + filepath));
   }
   var instream = fs.createReadStream(filepath);
   IO.read(instream, options, callback);

--- a/lib/mustang.js
+++ b/lib/mustang.js
@@ -126,7 +126,7 @@ function writeOutput(config, callback) {
   if (config.outputMultipleFiles) {
     if (!config.output) {
       return callback(new Error("Output directory path is not specified"));
-    } 
+    }
     if (!isDirectory(config.output)) {
       return callback(new Error("Output path is not a directory"));
     }


### PR DESCRIPTION
The -m option currently doesn't work - it tries to pull the path out of the context instead of config and tries to write to a directory path (which errors).
