### PR TITLE
Fix iconv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "0.2.x",
     "commander": "1.1.x",
     "csv": "0.3.x",
-    "iconv": "2.0.x",
+    "iconv": "^2.1.7",
     "mongodb": "1.3.x",
     "mustache": "0.7.x",
     "mysql": "2.0.x",


### PR DESCRIPTION
`npm install` currently fails on OS X, due to the old iconv version.
